### PR TITLE
Falsche Weiterleitung

### DIFF
--- a/module_postacomment/portal/class_module_postacomment_portal.php
+++ b/module_postacomment/portal/class_module_postacomment_portal.php
@@ -208,7 +208,7 @@ class class_module_postacomment_portal extends class_portal implements interface
         $objMessage->setStrMessageProvider(new class_messageprovider_postacomment());
         $objMessageHandler->sendMessageObject($objMessage, $arrGroups);
 
-        $this->portalReload(_indexpath_."?".$this->getHistory(0));
+        $this->portalReload(_indexpath_."?".$this->getHistory(1)/*."#comments"*/);
         return "";
     }
 


### PR DESCRIPTION
Kleines Beispiel macht deutlich klar worum es sich hier handelt. Auf
einer Seite wo die Detailansicht von den News ist und ich mit der
Klassischen Kommentar Funktion ein Kommentar schreibe werde ich nachdem
die Action PostComment ausgeführt wurde auf eine Detail Ansicht für
Kommentare weitergeleitet? Was eigentlich falsch ist weil ich doch
eigentlich zurück auf die NewsDetails Ansicht möchte. Eventuell auch mit
."#comments" für die richtige Verweisung in der Seite.
