### PR TITLE
Features/adminsimple object rights

### DIFF
--- a/module_system/admin/class_admin_simple.php
+++ b/module_system/admin/class_admin_simple.php
@@ -219,13 +219,16 @@ abstract class class_admin_simple extends class_admin_controller {
     /**
      * Renders a list of items, target is the common admin-list.
      * Please be aware, that the combination of paging and sortable-lists may result in unpredictable ordering.
-     * As soon as the list is sortable, the page-size should be at least the same as the number of elements
+     * As soon as the list is sortable, the page-size should be at least the same as the number of elements. Optional
+     * it is possible to provide a filter callback which is called for each entry. If the callback returns false the
+     * entry gets skipped.
      *
      * @param class_array_section_iterator $objArraySectionIterator
      * @param bool $bitSortable
      * @param string $strListIdentifier an internal identifier to check the current parent-list
      * @param bool $bitAllowTreeDrop
      * @param string $strPagerAddon
+     * @param Closure $objFilter
      *
      * @throws class_exception
      * @return string

--- a/module_system/admin/class_admin_simple.php
+++ b/module_system/admin/class_admin_simple.php
@@ -253,7 +253,8 @@ abstract class class_admin_simple extends class_admin_controller {
         /** @var $objOneIterable class_model|interface_model|interface_admin_listable */
         foreach($objArraySectionIterator as $objOneIterable) {
 
-            if(!$objOneIterable->rightView())
+            // we check the right only for models with an system id so that manual created objects still get in the list
+            if($objOneIterable->getStrSystemid() != '' && !$objOneIterable->rightView())
                 continue;
 
             $strActions = $this->getActionIcons($objOneIterable, $strListIdentifier);

--- a/module_system/admin/class_admin_simple.php
+++ b/module_system/admin/class_admin_simple.php
@@ -230,7 +230,7 @@ abstract class class_admin_simple extends class_admin_controller {
      * @throws class_exception
      * @return string
      */
-    protected function renderList(class_array_section_iterator $objArraySectionIterator, $bitSortable = false, $strListIdentifier = "", $bitAllowTreeDrop = false, $strPagerAddon = "") {
+    protected function renderList(class_array_section_iterator $objArraySectionIterator, $bitSortable = false, $strListIdentifier = "", $bitAllowTreeDrop = false, $strPagerAddon = "", Closure $objFilter = null) {
         $strReturn = "";
         $intI = 0;
 
@@ -253,9 +253,15 @@ abstract class class_admin_simple extends class_admin_controller {
         /** @var $objOneIterable class_model|interface_model|interface_admin_listable */
         foreach($objArraySectionIterator as $objOneIterable) {
 
-            // we check the right only for models with an system id so that manual created objects still get in the list
-            if($objOneIterable->getStrSystemid() != '' && !$objOneIterable->rightView())
+            // if we have a filter Closure call it else use the standard rightView method
+            if($objFilter !== null) {
+                if($objFilter($objOneIterable) === false) {
+                    continue;
+                }
+            }
+            else if(!$objOneIterable->rightView()) {
                 continue;
+            }
 
             $strActions = $this->getActionIcons($objOneIterable, $strListIdentifier);
             $strReturn .= $this->objToolkit->simpleAdminList($objOneIterable, $strActions, $intI++, count($arrMassActions) > 0);


### PR DESCRIPTION
This fix allows models to get into the admin list which have no systemid. In some cases we want create manual models (which are not stored in the database) and add them to the list. Without this fix it is not possible since the method rightView returns always false for an empty systemid. I dont know exactly whether there are cases where we have an model object which has no systemid and should not be displayed but for the case above this solution works.